### PR TITLE
change repo type to generic

### DIFF
--- a/repo.yml
+++ b/repo.yml
@@ -1,2 +1,2 @@
-type: hardware
+type: generic
 release: github


### PR DESCRIPTION
This is a docs repo - so shouldn't be subject to the hardware lab check - moving to a generic type repo to achieve this, as has been done in the fin qa docs repo

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>