### PR TITLE
Switch from balenaCI to Flowzone

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -1,0 +1,14 @@
+name: Flowzone
+
+on:
+  pull_request:
+    types: [opened, synchronize, closed]
+    branches:
+      - "main"
+      - "master"
+
+jobs:
+  flowzone:
+    name: Flowzone
+    uses: product-os/flowzone/.github/workflows/flowzone.yml@master
+    secrets: inherit


### PR DESCRIPTION
Adding the `flowzone.yml` file simultaneously enables [Flowzone](https://github.com/product-os/flowzone) and tells balenaCI not to bother.